### PR TITLE
:bug: 고정값 사용

### DIFF
--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -157,7 +157,7 @@ function SearchScreen() {
             />
           ) : (
             <>
-              <SearchResultSubTitle searchCount={searchFilter?.length} />
+              <SearchResultSubTitle searchCount={0} />
               <View style={styles.noSearchTextContainer}>
                 <Text style={styles.noSearchText}>검색 결과가 없습니다</Text>
               </View>


### PR DESCRIPTION
SearchFilter가 false인 경우, 길이를 읽을 수 없으므로, 그냥 고정값 0을 출력하도록 수정 #326